### PR TITLE
fix(chatbot): integración de cliente oficial para rag (cors y auth)

### DIFF
--- a/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
+++ b/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
@@ -1,30 +1,33 @@
 import semanticDictionaryRaw from './semantic_dictionary.json';
+import { PROJECTS_CLIENT } from "../../../Infraestructure/AxiosConfig";
 
 const semanticDictionary = semanticDictionaryRaw as Record<string, string>;
 
 // Caché en memoria para no saturar la red cada vez que el usuario chatea
 const ragCache: Record<string, string> = {};
 
-async function fetchProjectFull(projectId: string, token: string): Promise<any> {
-  const url = `${process.env.REACT_APP_URLVMSPROJECTS}/getProject?project_id=${projectId}`;
+async function fetchProjectFull(projectId: string): Promise<any> {
   try {
-    const response = await fetch(url, { headers: { "Authorization": `Bearer ${token}` } });
-    if (!response.ok) return null;
-    const data = await response.json();
-    return data.data;
+    const response = await PROJECTS_CLIENT.get(`/getProject`, { params: { project_id: projectId } });
+    let responseAPISuccess = response.data;
+    if (responseAPISuccess.message?.includes("Error")) {
+      throw new Error(JSON.stringify(response.data));
+    }
+    return responseAPISuccess.data;
   } catch (error) {
     console.error("Error fetching project in RAG:", error);
     return null;
   }
 }
 
-async function fetchTemplateProjectsMetadata(token: string): Promise<any[]> {
-  const url = `${process.env.REACT_APP_URLVMSPROJECTS}/getTemplateProjects`;
+async function fetchTemplateProjectsMetadata(): Promise<any[]> {
   try {
-    const response = await fetch(url, { headers: { "Authorization": `Bearer ${token}` } });
-    if (!response.ok) return [];
-    const data = await response.json();
-    return data.data?.projects || [];
+    const response = await PROJECTS_CLIENT.get("/getTemplateProjects");
+    let responseAPISuccess = response.data;
+    if (responseAPISuccess.message?.includes("Error")) {
+      throw new Error(JSON.stringify(response.data));
+    }
+    return responseAPISuccess.data?.projects || [];
   } catch (error) {
     console.error("Error fetching templates in RAG:", error);
     return [];
@@ -59,14 +62,14 @@ export async function getOrganicRAG(languageName: string): Promise<string> {
   }
 
   // 3. Buscar Modelos Dinámicos en los Templates Públicos
-  const cacheMetadata = await fetchTemplateProjectsMetadata(token);
+  const cacheMetadata = await fetchTemplateProjectsMetadata();
   const matchingModels: any[] = [];
   const seenNodeTypes = new Set<string>();
 
   for (const pMeta of cacheMetadata) {
     if (matchingModels.length >= 2) break; // Límite de modelos por contexto
     
-    const fullProject = await fetchProjectFull(pMeta.id, token);
+    const fullProject = await fetchProjectFull(pMeta.id);
     const productLines = fullProject?.project?.productLines;
     
     if (productLines) {


### PR DESCRIPTION
Corrige un error en el entorno de producción que impedía la descarga de modelos (arrojando la alerta de consola "no organic models found"). El problema se debía a que las políticas de seguridad del navegador CORS y el backend bloqueaban las peticiones mediante la API nativa fetch(). Se refactorizó el servicio OrganicRAGService.ts eliminando el uso de fetch(). Se importó el cliente oficial preconfigurado de VariaMos (PROJECTS_CLIENT instanciado desde AxiosConfig.ts). Las peticiones del RAG ahora heredan automáticamente los interceptores globales, inyectando el authToken y credenciales de forma segura y estandarizada. Se evita cualquier posible error de cors. Los ejemplos orgánicos se descargan correctamente y la IA vuelve a recibir la diversidad dinámica.