### PR TITLE
fix(chatbot): eliminar validación manual de token en localstorage par…

### DIFF
--- a/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
+++ b/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
@@ -55,13 +55,7 @@ export async function getOrganicRAG(languageName: string): Promise<string> {
     return `${semanticRulesText}\n[ORGANIC RAG EXAMPLES]\n${ragCache[baseLanguageName]}`.trim();
   }
 
-  // 2. Extraer el token de sesión del navegador
-  const token = localStorage.getItem("authToken") || "";
-  if (!token) {
-    return `${semanticRulesText}\n[ORGANIC RAG EXAMPLES]\n(no authentication token found)`.trim();
-  }
-
-  // 3. Buscar Modelos Dinámicos en los Templates Públicos
+  // 2. Buscar Modelos Dinámicos en los Templates Públicos
   const cacheMetadata = await fetchTemplateProjectsMetadata();
   const matchingModels: any[] = [];
   const seenNodeTypes = new Set<string>();


### PR DESCRIPTION
…a el rag

Anteriormente el servicio OrganicRAGService.ts revisaba manualmente la existencia de la llave "authToken" dentro del localStorage antes de continuar con el ciclo del RAG, sin embargo en el entorno de producción la gestión de la sesión ocurre a través del cliente de axios, al remover la condicional la responsabilidad de la autenticación se delega al PROJECTS_CLIENT evitando errores.