### PR TITLE
fix(chatbot): corregir parseo de json en extracción de modelos rag

### DIFF
--- a/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
+++ b/src/UI/WorkSpace/Chatbot/OrganicRAGService.ts
@@ -13,7 +13,7 @@ async function fetchProjectFull(projectId: string): Promise<any> {
     if (responseAPISuccess.message?.includes("Error")) {
       throw new Error(JSON.stringify(response.data));
     }
-    return responseAPISuccess.data;
+    return responseAPISuccess.data?.project;
   } catch (error) {
     console.error("Error fetching project in RAG:", error);
     return null;


### PR DESCRIPTION
Se corrige la ruta de extracción de objetos (Object Pathing) al recibir los datos de la API, lo que estaba impidiendo que el RAG encontrara los modelos de diagramas. Al consumir el endpoint /getProject, la respuesta de la API envuelve las líneas de producto en un nodo doble (data.project.project.productLines). En la versión inicial de producción, la función fetchProjectFull en OrganicRAGService.ts estaba devolviendo la raíz, lo que hacía que el puntero fallara al acceder a los modelos y marcara un (no organic models found). Se ajustó el valor de retorno a responseAPISuccess.data?.project para alinear con la estructura esperada por el buscador.